### PR TITLE
Create multi-page marketing experience for Drunkitties

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -6,118 +6,120 @@ const preview = document.getElementById('preview');
 const statusMessage = document.getElementById('formStatus');
 const results = document.getElementById('resultados');
 
-const readFileAsBase64 = (file) =>
-  new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => {
-      const base64 = reader.result.split(',')[1];
-      resolve(base64);
-    };
-    reader.onerror = () => reject(new Error('No pudimos leer el archivo.'));
-    reader.readAsDataURL(file);
-  });
-
-const clearResults = () => {
-  results.innerHTML = '';
-  results.setAttribute('aria-busy', 'false');
-};
-
-const setStatus = (message, type = 'info') => {
-  statusMessage.textContent = message;
-  statusMessage.dataset.statusType = type;
-};
-
-const showPreview = (file) => {
-  preview.innerHTML = '';
-  if (!file) {
-    preview.innerHTML = '<p class="preview__placeholder">Tu imagen aparecerá aquí en cuanto la selecciones.</p>';
-    return;
-  }
-
-  const img = document.createElement('img');
-  img.alt = `Vista previa de ${file.name}`;
-  img.className = 'preview__image';
-  img.src = URL.createObjectURL(file);
-  preview.appendChild(img);
-};
-
-fileInput.addEventListener('change', () => {
-  const [file] = fileInput.files;
-  showPreview(file);
-  clearResults();
-  setStatus('Listo para generar tus diseños ✨');
-});
-
-form.addEventListener('submit', async (event) => {
-  event.preventDefault();
-  const [file] = fileInput.files;
-
-  if (!file) {
-    setStatus('Selecciona primero la foto de tu mascota.', 'error');
-    return;
-  }
-
-  if (file.size > 4 * 1024 * 1024) {
-    setStatus('La imagen supera los 4 MB permitidos.', 'error');
-    return;
-  }
-
-  try {
-    form.classList.add('is-loading');
-    results.setAttribute('aria-busy', 'true');
-    clearResults();
-    setStatus('Generando magia felina… esto puede tardar unos segundos.');
-
-    const base64 = await readFileAsBase64(file);
-    const payload = {
-      image: base64,
-      variations: variationInput.value,
-      size: sizeSelect.value
-    };
-
-    const response = await fetch('/.netlify/functions/generate', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload)
+if (form && fileInput && variationInput && sizeSelect && preview && statusMessage && results) {
+  const readFileAsBase64 = (file) =>
+    new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => {
+        const base64 = reader.result.split(',')[1];
+        resolve(base64);
+      };
+      reader.onerror = () => reject(new Error('No pudimos leer el archivo.'));
+      reader.readAsDataURL(file);
     });
 
-    const data = await response.json();
+  const clearResults = () => {
+    results.innerHTML = '';
+    results.setAttribute('aria-busy', 'false');
+  };
 
-    if (!response.ok) {
-      throw new Error(data?.details || data?.error || 'Fallo inesperado.');
-    }
+  const setStatus = (message, type = 'info') => {
+    statusMessage.textContent = message;
+    statusMessage.dataset.statusType = type;
+  };
 
-    setStatus('¡Listo! Descarga tus nuevos diseños y compártelos.', 'success');
-
-    if (!data.images?.length) {
-      results.innerHTML = '<p class="results__empty">No se generaron imágenes. Intenta nuevamente.</p>';
+  const showPreview = (file) => {
+    preview.innerHTML = '';
+    if (!file) {
+      preview.innerHTML = '<p class="preview__placeholder">Tu imagen aparecerá aquí en cuanto la selecciones.</p>';
       return;
     }
 
-    const fragment = document.createDocumentFragment();
-    data.images.forEach((base64Image, index) => {
-      const figure = document.createElement('figure');
-      figure.className = 'result-card';
+    const img = document.createElement('img');
+    img.alt = `Vista previa de ${file.name}`;
+    img.className = 'preview__image';
+    img.src = URL.createObjectURL(file);
+    preview.appendChild(img);
+  };
 
-      const img = document.createElement('img');
-      img.src = `data:image/png;base64,${base64Image}`;
-      img.alt = `Variación ${index + 1} de tu mascota`;
-      img.loading = 'lazy';
+  fileInput.addEventListener('change', () => {
+    const [file] = fileInput.files;
+    showPreview(file);
+    clearResults();
+    setStatus('Listo para generar tus diseños ✨');
+  });
 
-      const caption = document.createElement('figcaption');
-      caption.textContent = `Variación ${index + 1}`;
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const [file] = fileInput.files;
 
-      figure.appendChild(img);
-      figure.appendChild(caption);
-      fragment.appendChild(figure);
-    });
+    if (!file) {
+      setStatus('Selecciona primero la foto de tu mascota.', 'error');
+      return;
+    }
 
-    results.appendChild(fragment);
-  } catch (error) {
-    console.error(error);
-    setStatus(error.message, 'error');
-  } finally {
-    form.classList.remove('is-loading');
-    results.setAttribute('aria-busy', 'false');
-  }
-});
+    if (file.size > 4 * 1024 * 1024) {
+      setStatus('La imagen supera los 4 MB permitidos.', 'error');
+      return;
+    }
+
+    try {
+      form.classList.add('is-loading');
+      results.setAttribute('aria-busy', 'true');
+      clearResults();
+      setStatus('Generando magia felina… esto puede tardar unos segundos.');
+
+      const base64 = await readFileAsBase64(file);
+      const payload = {
+        image: base64,
+        variations: variationInput.value,
+        size: sizeSelect.value
+      };
+
+      const response = await fetch('/.netlify/functions/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data?.details || data?.error || 'Fallo inesperado.');
+      }
+
+      setStatus('¡Listo! Descarga tus nuevos diseños y compártelos.', 'success');
+
+      if (!data.images?.length) {
+        results.innerHTML = '<p class="results__empty">No se generaron imágenes. Intenta nuevamente.</p>';
+        return;
+      }
+
+      const fragment = document.createDocumentFragment();
+      data.images.forEach((base64Image, index) => {
+        const figure = document.createElement('figure');
+        figure.className = 'result-card';
+
+        const img = document.createElement('img');
+        img.src = `data:image/png;base64,${base64Image}`;
+        img.alt = `Variación ${index + 1} de tu mascota`;
+        img.loading = 'lazy';
+
+        const caption = document.createElement('figcaption');
+        caption.textContent = `Variación ${index + 1}`;
+
+        figure.appendChild(img);
+        figure.appendChild(caption);
+        fragment.appendChild(figure);
+      });
+
+      results.appendChild(fragment);
+    } catch (error) {
+      console.error(error);
+      setStatus(error.message, 'error');
+    } finally {
+      form.classList.remove('is-loading');
+      results.setAttribute('aria-busy', 'false');
+    }
+  });
+}

--- a/public/carrito/index.html
+++ b/public/carrito/index.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Carrito de compras · Drunkitties</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="../style.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="site-header__container">
+        <a class="site-logo" href="/">🐾 Drunkitties</a>
+        <nav class="site-nav" aria-label="Principal">
+          <a href="/">Inicio</a>
+          <a href="/productos/">Productos</a>
+          <a href="/personalizar/">Personalizar</a>
+          <a href="/contacto/">Contacto</a>
+        </nav>
+        <a class="site-header__cta" href="/personalizar/">Empieza ahora</a>
+      </div>
+    </header>
+
+    <main class="page-main">
+      <section class="page-hero">
+        <h1 class="page-hero__title">Tu carrito</h1>
+        <p class="page-hero__subtitle">Revisa tu selección antes de pasar al checkout. Ajusta cantidades o elimina productos cuando quieras.</p>
+      </section>
+
+      <section class="cart-list" aria-label="Resumen de carrito">
+        <article class="cart-item">
+          <div class="cart-item__info">
+            <strong>Mousepad personalizado</strong>
+            <span>Estilo: Pastel ilustrado · Tamaño: Pequeño</span>
+          </div>
+          <strong>€8,000</strong>
+        </article>
+        <article class="cart-item">
+          <div class="cart-item__info">
+            <strong>Taza personalizada</strong>
+            <span>Estilo: Comic pop · Cantidad: 2</span>
+          </div>
+          <strong>€13,000</strong>
+        </article>
+      </section>
+
+      <section class="summary-card" aria-label="Totales">
+        <h2>Resumen</h2>
+        <p><strong>Subtotal:</strong> €21,000</p>
+        <p><strong>Envío:</strong> Gratis</p>
+        <p class="summary-card__total">Total: €21,000</p>
+        <a class="product-card__cta" href="/checkout/">Continuar al pago</a>
+        <a class="button-secondary" href="/productos/">Seguir comprando</a>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-footer__inner">
+        <p>Hecho con ❤️ para amantes de los bigotes inquietos.</p>
+        <nav class="footer-nav" aria-label="Legal">
+          <a href="/sobre-nosotros/">Sobre nosotros</a>
+          <a href="/privacidad/">Política de privacidad</a>
+          <a href="/terminos/">Términos y condiciones</a>
+          <a href="/contacto/">Contacto</a>
+        </nav>
+        <p class="site-footer__credits">© 2025 Drunkitties Studio. Todos los derechos reservados.</p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/public/checkout/index.html
+++ b/public/checkout/index.html
@@ -1,0 +1,101 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Checkout · Drunkitties</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="../style.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="site-header__container">
+        <a class="site-logo" href="/">🐾 Drunkitties</a>
+        <nav class="site-nav" aria-label="Principal">
+          <a href="/">Inicio</a>
+          <a href="/productos/">Productos</a>
+          <a href="/personalizar/">Personalizar</a>
+          <a href="/contacto/">Contacto</a>
+        </nav>
+        <a class="site-header__cta" href="/personalizar/">Empieza ahora</a>
+      </div>
+    </header>
+
+    <main class="page-main">
+      <section class="page-hero">
+        <h1 class="page-hero__title">Checkout / Pago</h1>
+        <p class="page-hero__subtitle">Ingresa tus datos y completa la compra para que tu mascota llegue a todos tus accesorios.</p>
+      </section>
+
+      <section class="checkout-grid">
+        <form class="customization__form" aria-label="Formulario de pago">
+          <div class="form-field">
+            <label for="name">Nombre completo</label>
+            <input type="text" id="name" name="name" placeholder="Nombre y apellidos" />
+          </div>
+          <div class="form-field">
+            <label for="email">Correo electrónico</label>
+            <input type="email" id="email" name="email" placeholder="nombre@ejemplo.com" />
+          </div>
+          <div class="form-field">
+            <label for="address">Dirección de envío</label>
+            <input type="text" id="address" name="address" placeholder="Calle, número, ciudad" />
+          </div>
+          <div class="form-row">
+            <div class="form-field">
+              <label for="zip">Código postal</label>
+              <input type="text" id="zip" name="zip" placeholder="00000" />
+            </div>
+            <div class="form-field">
+              <label for="country">País</label>
+              <input type="text" id="country" name="country" placeholder="México" />
+            </div>
+          </div>
+          <div class="form-field">
+            <label for="card">Número de tarjeta</label>
+            <input type="text" id="card" name="card" placeholder="0000 0000 0000 0000" />
+          </div>
+          <div class="form-row">
+            <div class="form-field">
+              <label for="expiry">Fecha de expiración</label>
+              <input type="text" id="expiry" name="expiry" placeholder="MM/AA" />
+            </div>
+            <div class="form-field">
+              <label for="cvv">CVV</label>
+              <input type="text" id="cvv" name="cvv" placeholder="123" />
+            </div>
+          </div>
+          <button class="submit-button" type="button">Confirmar y pagar</button>
+        </form>
+
+        <aside class="customization__preview">
+          <h3>Resumen del pedido</h3>
+          <div class="summary-card">
+            <p><strong>Mousepad personalizado</strong></p>
+            <p>Estilo: Pastel ilustrado</p>
+            <p>Tamaño: Pequeño</p>
+            <p><strong>Taza personalizada</strong></p>
+            <p>Estilo: Comic pop</p>
+            <p class="summary-card__total">Total: €21,000</p>
+          </div>
+          <p>Al confirmar aceptas nuestras <a href="/terminos/">condiciones de servicio</a> y la <a href="/privacidad/">política de privacidad</a>.</p>
+        </aside>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-footer__inner">
+        <p>Hecho con ❤️ para amantes de los bigotes inquietos.</p>
+        <nav class="footer-nav" aria-label="Legal">
+          <a href="/sobre-nosotros/">Sobre nosotros</a>
+          <a href="/privacidad/">Política de privacidad</a>
+          <a href="/terminos/">Términos y condiciones</a>
+          <a href="/contacto/">Contacto</a>
+        </nav>
+        <p class="site-footer__credits">© 2025 Drunkitties Studio. Todos los derechos reservados.</p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/public/contacto/index.html
+++ b/public/contacto/index.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Contacto · Drunkitties</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="../style.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="site-header__container">
+        <a class="site-logo" href="/">🐾 Drunkitties</a>
+        <nav class="site-nav" aria-label="Principal">
+          <a href="/">Inicio</a>
+          <a href="/productos/">Productos</a>
+          <a href="/personalizar/">Personalizar</a>
+          <a href="/contacto/" aria-current="page">Contacto</a>
+        </nav>
+        <a class="site-header__cta" href="/personalizar/">Empieza ahora</a>
+      </div>
+    </header>
+
+    <main class="page-main">
+      <section class="page-hero">
+        <h1 class="page-hero__title">Ponte en contacto</h1>
+        <p class="page-hero__subtitle">¿Tienes dudas, colaboraciones o quieres distribuir Drunkitties en tu tienda? Estamos para ayudarte.</p>
+      </section>
+
+      <section class="customization__grid">
+        <form class="customization__form" aria-label="Formulario de contacto">
+          <div class="form-field">
+            <label for="contactName">Nombre completo</label>
+            <input type="text" id="contactName" name="contactName" placeholder="Tu nombre" />
+          </div>
+          <div class="form-field">
+            <label for="contactEmail">Correo electrónico</label>
+            <input type="email" id="contactEmail" name="contactEmail" placeholder="nombre@ejemplo.com" />
+          </div>
+          <div class="form-field">
+            <label for="topic">Motivo</label>
+            <select id="topic" name="topic">
+              <option value="soporte">Soporte técnico</option>
+              <option value="ventas">Ventas al mayoreo</option>
+              <option value="colaboracion">Colaboraciones</option>
+              <option value="otro">Otro</option>
+            </select>
+          </div>
+          <div class="form-field">
+            <label for="message">Mensaje</label>
+            <textarea id="message" name="message" rows="5" placeholder="Cuéntanos en qué podemos ayudarte."></textarea>
+          </div>
+          <button class="submit-button" type="button">Enviar mensaje</button>
+        </form>
+
+        <aside class="customization__preview">
+          <h3>Atención personalizada</h3>
+          <p>Respondemos en menos de 24 horas hábiles. También puedes escribirnos directamente a <a href="mailto:hola@drunkitties.studio">hola@drunkitties.studio</a>.</p>
+          <div class="summary-card">
+            <h4>Horarios</h4>
+            <p>Lunes a viernes · 10:00 a 18:00 (CDMX)</p>
+            <p>Sábados · 11:00 a 14:00</p>
+            <p class="summary-card__total">Soporte urgente: +52 55 1234 5678</p>
+          </div>
+        </aside>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-footer__inner">
+        <p>Hecho con ❤️ para amantes de los bigotes inquietos.</p>
+        <nav class="footer-nav" aria-label="Legal">
+          <a href="/sobre-nosotros/">Sobre nosotros</a>
+          <a href="/privacidad/">Política de privacidad</a>
+          <a href="/terminos/">Términos y condiciones</a>
+          <a href="/contacto/" aria-current="page">Contacto</a>
+        </nav>
+        <p class="site-footer__credits">© 2025 Drunkitties Studio. Todos los derechos reservados.</p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -10,26 +10,41 @@
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>
-    <header class="hero">
-      <div class="hero__content">
-        <p class="hero__badge">Drunkitties Studio</p>
-        <h1 class="hero__title">Convierte a tu mascota en la estrella de la colección</h1>
-        <p class="hero__subtitle">
-          Sube una foto de tu compañero peludo y deja que nuestra inteligencia artificial imagine
-          diseños únicos para camisetas, hoodies y accesorios irresistibles.
-        </p>
-        <a class="hero__cta" href="#generador">Comenzar</a>
-      </div>
-      <div class="hero__mockup" aria-hidden="true">
-        <div class="mockup-card">
-          <span class="mockup-card__tag">Novedad</span>
-          <p class="mockup-card__title">Colección Urban Whiskers</p>
-          <p class="mockup-card__text">Diseños personalizados con la actitud de tu mascota.</p>
-        </div>
+    <header class="site-header">
+      <div class="site-header__container">
+        <a class="site-logo" href="/">🐾 Drunkitties</a>
+        <nav class="site-nav" aria-label="Principal">
+          <a href="/" aria-current="page">Inicio</a>
+          <a href="/productos/">Productos</a>
+          <a href="/personalizar/">Personalizar</a>
+          <a href="/contacto/">Contacto</a>
+        </nav>
+        <a class="site-header__cta" href="/personalizar/">Empieza ahora</a>
       </div>
     </header>
 
     <main>
+      <section class="hero hero--home">
+        <div class="hero__content">
+          <p class="hero__badge">Drunkitties Studio</p>
+          <h1 class="hero__title">Convierte a tu mascota en la estrella de la colección</h1>
+          <p class="hero__subtitle">
+            Sube una foto de tu compañero peludo y deja que nuestra inteligencia artificial imagine diseños únicos para camisetas, hoodies y accesorios irresistibles.
+          </p>
+          <div class="hero__actions">
+            <a class="hero__cta" href="/personalizar/">Crear un diseño</a>
+            <a class="hero__link" href="/productos/">Ver catálogo</a>
+          </div>
+        </div>
+        <div class="hero__mockup" aria-hidden="true">
+          <div class="mockup-card">
+            <span class="mockup-card__tag">Novedad</span>
+            <p class="mockup-card__title">Colección Urban Whiskers</p>
+            <p class="mockup-card__text">Diseños personalizados con la actitud de tu mascota.</p>
+          </div>
+        </div>
+      </section>
+
       <section class="highlights" aria-labelledby="destacados">
         <div class="section-header">
           <h2 id="destacados">¿Por qué Drunkitties?</h2>
@@ -98,8 +113,7 @@
           <div>
             <dt>¿Qué pasa con mis imágenes?</dt>
             <dd>
-              Se usan únicamente para generar las variaciones solicitadas. Recuerda añadir tu clave de OpenAI en
-              Netlify para mantener todo seguro.
+              Se usan únicamente para generar las variaciones solicitadas. Recuerda añadir tu clave de OpenAI en Netlify para mantener todo seguro.
             </dd>
           </div>
           <div>
@@ -111,8 +125,7 @@
           <div>
             <dt>¿Qué hago si aparece un error?</dt>
             <dd>
-              Asegúrate de que la imagen pesa menos de 4&nbsp;MB y que tu clave de OpenAI es válida. Si el problema
-              continúa, vuelve a intentarlo en unos minutos.
+              Asegúrate de que la imagen pesa menos de 4&nbsp;MB y que tu clave de OpenAI es válida. Si el problema continúa, vuelve a intentarlo en unos minutos.
             </dd>
           </div>
         </dl>
@@ -120,8 +133,16 @@
     </main>
 
     <footer class="site-footer">
-      <p>Hecho con ❤️ para amantes de los bigotes inquietos.</p>
-      <p class="site-footer__credits">Listo para desplegar en Netlify.</p>
+      <div class="site-footer__inner">
+        <p>Hecho con ❤️ para amantes de los bigotes inquietos.</p>
+        <nav class="footer-nav" aria-label="Legal">
+          <a href="/sobre-nosotros/">Sobre nosotros</a>
+          <a href="/privacidad/">Política de privacidad</a>
+          <a href="/terminos/">Términos y condiciones</a>
+          <a href="/contacto/">Contacto</a>
+        </nav>
+        <p class="site-footer__credits">© 2025 Drunkitties Studio. Todos los derechos reservados.</p>
+      </div>
     </footer>
 
     <script src="app.js" type="module"></script>

--- a/public/personalizar/index.html
+++ b/public/personalizar/index.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Personaliza tu producto · Drunkitties</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="../style.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="site-header__container">
+        <a class="site-logo" href="/">🐾 Drunkitties</a>
+        <nav class="site-nav" aria-label="Principal">
+          <a href="/">Inicio</a>
+          <a href="/productos/">Productos</a>
+          <a href="/personalizar/" aria-current="page">Personalizar</a>
+          <a href="/contacto/">Contacto</a>
+        </nav>
+        <a class="site-header__cta" href="/personalizar/">Empieza ahora</a>
+      </div>
+    </header>
+
+    <main class="page-main">
+      <section class="page-hero">
+        <span class="page-hero__eyebrow">Producto a personalizar</span>
+        <h1 class="page-hero__title">Mousepad personalizado</h1>
+        <p class="page-hero__price">€8,000</p>
+        <p class="page-hero__subtitle">
+          Convierte tu escritorio en una galería de arte con tu mascota como protagonista. Elige el estilo, tamaño y sube una foto para generar tu diseño único.
+        </p>
+      </section>
+
+      <section class="customization">
+        <div class="customization__grid">
+          <form class="customization__form">
+            <div class="form-field">
+              <label for="petImagePersonalizar">Imagen de tu mascota</label>
+              <input type="file" id="petImagePersonalizar" name="petImagePersonalizar" accept="image/*" />
+              <p class="field-hint">JPG o PNG, máximo 4 MB. Usa una foto nítida y bien iluminada.</p>
+            </div>
+
+            <div class="form-field">
+              <label for="artStyle">Estilo artístico</label>
+              <select id="artStyle" name="artStyle">
+                <option value="pastel">Pastel ilustrado</option>
+                <option value="realista">Realista vibrante</option>
+                <option value="comic">Comic pop</option>
+                <option value="minimalista">Minimalista monocromático</option>
+              </select>
+            </div>
+
+            <div class="form-field">
+              <label for="productSize">Tamaño del producto</label>
+              <select id="productSize" name="productSize">
+                <option value="pequeno">Pequeño (25 × 20 cm)</option>
+                <option value="mediano">Mediano (32 × 25 cm)</option>
+                <option value="grande">Grande (36 × 30 cm)</option>
+              </select>
+            </div>
+
+            <div class="form-field">
+              <label for="notes">Notas adicionales</label>
+              <textarea id="notes" name="notes" rows="4" placeholder="Cuéntanos los detalles que quieres resaltar."></textarea>
+            </div>
+
+            <button class="submit-button" type="button">Generar vista previa</button>
+          </form>
+
+          <aside class="customization__preview">
+            <h3>Vista previa generada</h3>
+            <p>¡Aquí aparecerá tu diseño personalizado una vez que generes la vista previa!</p>
+            <div class="preview" aria-live="polite">
+              <p class="preview__placeholder">Sube una imagen para desbloquear la magia felina.</p>
+            </div>
+            <div class="summary-card">
+              <h4>Tu selección</h4>
+              <p><strong>Estilo:</strong> Pastel ilustrado</p>
+              <p><strong>Tamaño:</strong> Pequeño</p>
+              <p class="summary-card__total">Total estimado: €8,000</p>
+              <a class="product-card__cta" href="/carrito/">Añadir al carrito</a>
+            </div>
+          </aside>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-footer__inner">
+        <p>Hecho con ❤️ para amantes de los bigotes inquietos.</p>
+        <nav class="footer-nav" aria-label="Legal">
+          <a href="/sobre-nosotros/">Sobre nosotros</a>
+          <a href="/privacidad/">Política de privacidad</a>
+          <a href="/terminos/">Términos y condiciones</a>
+          <a href="/contacto/">Contacto</a>
+        </nav>
+        <p class="site-footer__credits">© 2025 Drunkitties Studio. Todos los derechos reservados.</p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/public/privacidad/index.html
+++ b/public/privacidad/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Política de privacidad · Drunkitties</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="../style.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="site-header__container">
+        <a class="site-logo" href="/">🐾 Drunkitties</a>
+        <nav class="site-nav" aria-label="Principal">
+          <a href="/">Inicio</a>
+          <a href="/productos/">Productos</a>
+          <a href="/personalizar/">Personalizar</a>
+          <a href="/contacto/">Contacto</a>
+        </nav>
+        <a class="site-header__cta" href="/personalizar/">Empieza ahora</a>
+      </div>
+    </header>
+
+    <main class="page-main">
+      <section class="page-hero">
+        <h1 class="page-hero__title">Política de privacidad</h1>
+        <p class="page-hero__subtitle">Nos tomamos en serio la protección de tus datos y de las fotos de tus mascotas.</p>
+      </section>
+
+      <section class="rich-text">
+        <h2>1. Información que recopilamos</h2>
+        <p>Recopilamos datos mínimos para ofrecerte el servicio: nombre, correo electrónico y las imágenes que subes para generar tus diseños.</p>
+
+        <h2>2. Uso de la información</h2>
+        <p>Solo utilizamos tus datos para procesar tus pedidos, mejorar el producto y enviarte comunicaciones relevantes (si lo autorizas).</p>
+
+        <h2>3. Conservación de archivos</h2>
+        <p>Las imágenes generadas se almacenan temporalmente para permitir descargas durante 30 días. Después se eliminan automáticamente.</p>
+
+        <h2>4. Tus derechos</h2>
+        <p>Puedes solicitar acceso, corrección o eliminación de tus datos escribiendo a <a href="mailto:privacidad@drunkitties.studio">privacidad@drunkitties.studio</a>.</p>
+
+        <h2>5. Actualizaciones</h2>
+        <p>Actualizaremos esta política cuando haya cambios importantes. La fecha de la última revisión es enero 2025.</p>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-footer__inner">
+        <p>Hecho con ❤️ para amantes de los bigotes inquietos.</p>
+        <nav class="footer-nav" aria-label="Legal">
+          <a href="/sobre-nosotros/">Sobre nosotros</a>
+          <a href="/privacidad/" aria-current="page">Política de privacidad</a>
+          <a href="/terminos/">Términos y condiciones</a>
+          <a href="/contacto/">Contacto</a>
+        </nav>
+        <p class="site-footer__credits">© 2025 Drunkitties Studio. Todos los derechos reservados.</p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/public/productos/index.html
+++ b/public/productos/index.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Catálogo de productos · Drunkitties</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="../style.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="site-header__container">
+        <a class="site-logo" href="/">🐾 Drunkitties</a>
+        <nav class="site-nav" aria-label="Principal">
+          <a href="/">Inicio</a>
+          <a href="/productos/" aria-current="page">Productos</a>
+          <a href="/personalizar/">Personalizar</a>
+          <a href="/contacto/">Contacto</a>
+        </nav>
+        <a class="site-header__cta" href="/personalizar/">Empieza ahora</a>
+      </div>
+    </header>
+
+    <main class="page-main">
+      <section class="page-hero page-hero--center">
+        <h1 class="page-hero__title">Catálogo de productos</h1>
+        <p class="page-hero__subtitle">Personaliza tu estilo con el encanto de tu mascota 🐾✨</p>
+        <div class="pill-group" role="tablist" aria-label="Categorías de producto">
+          <span class="pill is-active" role="tab" aria-selected="true">Todo</span>
+          <span class="pill" role="tab" aria-selected="false">Mousepads</span>
+          <span class="pill" role="tab" aria-selected="false">Tazas</span>
+          <span class="pill" role="tab" aria-selected="false">Camisetas</span>
+          <span class="pill" role="tab" aria-selected="false">Hoodies</span>
+        </div>
+      </section>
+
+      <section class="product-grid" aria-label="Listado de productos">
+        <article class="product-card">
+          <div class="product-card__header">
+            <span class="product-card__emoji" aria-hidden="true">🖱️</span>
+            <div>
+              <p class="product-card__title">Mousepad personalizado</p>
+              <p class="product-card__price">€8,000</p>
+            </div>
+          </div>
+          <p>Convierte tu escritorio en una galería dedicada a tu mascota con acabados premium y base antideslizante.</p>
+          <a class="product-card__cta" href="/personalizar/">Personalizar</a>
+        </article>
+
+        <article class="product-card">
+          <div class="product-card__header">
+            <span class="product-card__emoji" aria-hidden="true">☕</span>
+            <div>
+              <p class="product-card__title">Taza personalizada</p>
+              <p class="product-card__price">€6,500</p>
+            </div>
+          </div>
+          <p>Empieza el día con una dosis de ternura felina y un diseño resistente al microondas y lavavajillas.</p>
+          <a class="product-card__cta" href="/personalizar/">Personalizar</a>
+        </article>
+
+        <article class="product-card">
+          <div class="product-card__header">
+            <span class="product-card__emoji" aria-hidden="true">👕</span>
+            <div>
+              <p class="product-card__title">Camiseta personalizada</p>
+              <p class="product-card__price">€12,000</p>
+            </div>
+          </div>
+          <p>Algodón orgánico, tintas vibrantes y tu mascota protagonizando cada mirada. Disponible en todas las tallas.</p>
+          <a class="product-card__cta" href="/personalizar/">Personalizar</a>
+        </article>
+
+        <article class="product-card">
+          <div class="product-card__header">
+            <span class="product-card__emoji" aria-hidden="true">🧥</span>
+            <div>
+              <p class="product-card__title">Hoodie personalizado</p>
+              <p class="product-card__price">€18,000</p>
+            </div>
+          </div>
+          <p>Comodidad absoluta, interior afelpado y la personalidad de tu mascota bordada en cada detalle.</p>
+          <a class="product-card__cta" href="/personalizar/">Personalizar</a>
+        </article>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-footer__inner">
+        <p>Hecho con ❤️ para amantes de los bigotes inquietos.</p>
+        <nav class="footer-nav" aria-label="Legal">
+          <a href="/sobre-nosotros/">Sobre nosotros</a>
+          <a href="/privacidad/">Política de privacidad</a>
+          <a href="/terminos/">Términos y condiciones</a>
+          <a href="/contacto/">Contacto</a>
+        </nav>
+        <p class="site-footer__credits">© 2025 Drunkitties Studio. Todos los derechos reservados.</p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/public/sobre-nosotros/index.html
+++ b/public/sobre-nosotros/index.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Sobre nosotros · Drunkitties</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="../style.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="site-header__container">
+        <a class="site-logo" href="/">🐾 Drunkitties</a>
+        <nav class="site-nav" aria-label="Principal">
+          <a href="/">Inicio</a>
+          <a href="/productos/">Productos</a>
+          <a href="/personalizar/">Personalizar</a>
+          <a href="/contacto/">Contacto</a>
+        </nav>
+        <a class="site-header__cta" href="/personalizar/">Empieza ahora</a>
+      </div>
+    </header>
+
+    <main class="page-main">
+      <section class="page-hero">
+        <h1 class="page-hero__title">Sobre Drunkitties</h1>
+        <p class="page-hero__subtitle">Somos un estudio independiente que combina creatividad, tecnología y mucho amor por las mascotas.</p>
+      </section>
+
+      <section class="rich-text">
+        <h2>Nuestra historia</h2>
+        <p>
+          Drunkitties nació durante una tarde de juegos con nuestros gatos adoptados. Queríamos camisetas con sus caras pero los diseños tradicionales no capturaban su personalidad. Así que combinamos nuestras habilidades en ilustración, desarrollo web e inteligencia artificial para crear un generador que transformara cualquier foto en arte listo para usar.
+        </p>
+        <p>
+          Hoy ayudamos a miles de pet lovers a crear merchandising premium sin complicaciones: solo subes una foto, eliges un estilo y listo, obtienes diseños increíbles para tus productos favoritos.
+        </p>
+        <h2>Nuestro compromiso</h2>
+        <ul>
+          <li>Brindar herramientas accesibles para pequeñas marcas y emprendedores pet friendly.</li>
+          <li>Producir materiales de alta calidad con proveedores responsables.</li>
+          <li>Apoyar refugios locales donando un porcentaje de cada compra.</li>
+        </ul>
+      </section>
+
+      <section class="summary-card">
+        <h2>Conoce al equipo</h2>
+        <p><strong>María</strong> · Directora Creativa · Fanática de los gatos siameses.</p>
+        <p><strong>Diego</strong> · Ingeniero de IA · Papá de un bulldog francés.</p>
+        <p><strong>Lau</strong> · Especialista en experiencia de usuario · Cuida a tres rescatados.</p>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-footer__inner">
+        <p>Hecho con ❤️ para amantes de los bigotes inquietos.</p>
+        <nav class="footer-nav" aria-label="Legal">
+          <a href="/sobre-nosotros/" aria-current="page">Sobre nosotros</a>
+          <a href="/privacidad/">Política de privacidad</a>
+          <a href="/terminos/">Términos y condiciones</a>
+          <a href="/contacto/">Contacto</a>
+        </nav>
+        <p class="site-footer__credits">© 2025 Drunkitties Studio. Todos los derechos reservados.</p>
+      </div>
+    </footer>
+  </body>
+</html>

--- a/public/style.css
+++ b/public/style.css
@@ -2,6 +2,7 @@
   color-scheme: light;
   --bg: #f8f6ff;
   --bg-card: #ffffff;
+  --bg-subtle: rgba(255, 255, 255, 0.7);
   --bg-highlight: linear-gradient(135deg, #ffccf9, #c7f5ff);
   --text: #1f1f2b;
   --muted: #5f5f76;
@@ -21,27 +22,117 @@ body {
   background: var(--bg);
   color: var(--text);
   line-height: 1.6;
+  font-family: inherit;
 }
 
 a {
   color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+img {
+  max-width: 100%;
+  display: block;
 }
 
 main {
   display: flex;
   flex-direction: column;
   gap: clamp(3rem, 8vw, 5rem);
-  padding: 0 clamp(1.5rem, 6vw, 6rem) clamp(4rem, 10vw, 6rem);
+  padding: clamp(3rem, 8vw, 5rem) clamp(1.5rem, 6vw, 6rem) clamp(4rem, 10vw, 6rem);
+}
+
+main > * {
+  width: min(1120px, 100%);
+  margin-inline: auto;
+}
+
+.site-header {
+  background: var(--bg-card);
+  box-shadow: 0 12px 24px rgba(31, 31, 43, 0.05);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.site-header__container {
+  width: min(1120px, 100%);
+  margin: 0 auto;
+  padding: 1rem clamp(1.5rem, 6vw, 6rem);
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.site-logo {
+  font-weight: 700;
+  font-size: 1.1rem;
+  letter-spacing: 0.02em;
+}
+
+.site-nav {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-left: auto;
+  margin-right: 1rem;
+}
+
+.site-nav a {
+  padding: 0.5rem 0.75rem;
+  border-radius: 999px;
+  font-weight: 600;
+  color: var(--muted);
+  text-decoration: none;
+}
+
+.site-nav a[aria-current='page'] {
+  background: rgba(108, 75, 244, 0.12);
+  color: var(--primary-strong);
+}
+
+.site-nav a:hover,
+.site-nav a:focus {
+  color: var(--primary-strong);
+  text-decoration: none;
+}
+
+.site-header__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.65rem 1.4rem;
+  border-radius: 999px;
+  background: var(--primary);
+  color: #fff;
+  font-weight: 700;
+  text-decoration: none;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.site-header__cta:hover {
+  background: var(--primary-strong);
+  transform: translateY(-2px);
 }
 
 .hero {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
   gap: clamp(2rem, 5vw, 4rem);
-  padding: clamp(3rem, 8vw, 5rem) clamp(1.5rem, 6vw, 6rem) clamp(4rem, 10vw, 6rem);
+  padding: clamp(3rem, 8vw, 5rem);
   background: radial-gradient(circle at top left, rgba(108, 75, 244, 0.16), transparent 60%),
     radial-gradient(circle at bottom right, rgba(255, 143, 177, 0.12), transparent 55%),
     var(--bg);
+  border-radius: 32px;
+}
+
+.hero--home {
+  margin-top: clamp(1rem, 4vw, 2rem);
 }
 
 .hero__badge {
@@ -69,9 +160,15 @@ main {
   font-size: clamp(1rem, 3vw, 1.2rem);
 }
 
+.hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
 .hero__cta {
   display: inline-flex;
-  margin-top: 1.5rem;
   padding: 0.9rem 1.8rem;
   background: var(--primary);
   color: #fff;
@@ -84,6 +181,17 @@ main {
 .hero__cta:hover {
   background: var(--primary-strong);
   transform: translateY(-2px);
+}
+
+.hero__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.9rem 1.6rem;
+  border-radius: 999px;
+  background: rgba(108, 75, 244, 0.1);
+  color: var(--primary-strong);
+  font-weight: 600;
 }
 
 .hero__mockup {
@@ -208,16 +316,19 @@ main {
 }
 
 .form-field input,
-.form-field select {
+.form-field select,
+.form-field textarea {
   padding: 0.75rem 1rem;
   border: 1.5px solid rgba(108, 75, 244, 0.2);
   border-radius: 12px;
   font: inherit;
   background: #fdfdff;
+  resize: vertical;
 }
 
 .form-field input:focus,
-.form-field select:focus {
+.form-field select:focus,
+.form-field textarea:focus {
   outline: 3px solid rgba(108, 75, 244, 0.25);
 }
 
@@ -326,6 +437,234 @@ main {
   color: var(--muted);
 }
 
+.page-hero {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.page-hero--center {
+  text-align: center;
+  place-items: center;
+}
+
+.page-hero__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  background: rgba(108, 75, 244, 0.15);
+  color: var(--primary-strong);
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.page-hero__title {
+  font-size: clamp(2rem, 4vw, 3rem);
+  margin: 0;
+}
+
+.page-hero__subtitle {
+  color: var(--muted);
+  max-width: 60ch;
+}
+
+.page-hero__price {
+  font-size: clamp(1.8rem, 4vw, 2.4rem);
+  font-weight: 700;
+  color: var(--primary-strong);
+}
+
+.pill-group {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.pill {
+  padding: 0.5rem 1.2rem;
+  border-radius: 999px;
+  background: rgba(108, 75, 244, 0.1);
+  color: var(--primary-strong);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.pill.is-active {
+  background: var(--primary);
+  color: #fff;
+}
+
+.product-grid {
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 2rem);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.product-card {
+  padding: 1.75rem;
+  background: var(--bg-card);
+  border-radius: 24px;
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 1.2rem;
+}
+
+.product-card__header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.product-card__emoji {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 14px;
+  background: rgba(108, 75, 244, 0.12);
+  font-size: 1.4rem;
+}
+
+.product-card__title {
+  font-size: 1.1rem;
+  font-weight: 700;
+  margin: 0;
+}
+
+.product-card__price {
+  font-weight: 700;
+  color: var(--primary-strong);
+}
+
+.product-card__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.4rem;
+  border-radius: 999px;
+  background: var(--primary);
+  color: #fff;
+  font-weight: 700;
+  text-decoration: none;
+  transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.product-card__cta:hover {
+  background: var(--primary-strong);
+  transform: translateY(-2px);
+}
+
+.customization {
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.customization__grid {
+  display: grid;
+  gap: clamp(2rem, 5vw, 3rem);
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: start;
+}
+
+.customization__preview {
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  background: var(--bg-card);
+  border-radius: 24px;
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 1rem;
+}
+
+.customization__preview h3 {
+  margin: 0;
+}
+
+.customization__preview p {
+  color: var(--muted);
+}
+
+.customization__form {
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 2rem);
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  background: var(--bg-card);
+  border-radius: 24px;
+  box-shadow: var(--shadow);
+}
+
+.summary-card {
+  padding: 1.5rem;
+  background: var(--bg-card);
+  border-radius: 20px;
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.summary-card__total {
+  font-size: 1.3rem;
+  font-weight: 700;
+  color: var(--primary-strong);
+}
+
+.cart-list {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.cart-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.2rem 1.5rem;
+  background: var(--bg-card);
+  border-radius: 18px;
+  box-shadow: var(--shadow);
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.cart-item__info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.checkout-grid {
+  display: grid;
+  gap: clamp(2rem, 5vw, 3rem);
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: start;
+}
+
+.button-secondary {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  border: 1.5px solid rgba(108, 75, 244, 0.2);
+  background: transparent;
+  color: var(--primary-strong);
+  font-weight: 700;
+  cursor: pointer;
+}
+
+.rich-text {
+  display: grid;
+  gap: 1.2rem;
+  color: var(--muted);
+}
+
+.rich-text h2,
+.rich-text h3 {
+  color: var(--text);
+  margin-bottom: 0.5rem;
+}
+
 .site-footer {
   padding: 2.5rem clamp(1.5rem, 6vw, 6rem) 3rem;
   background: #1f1f2b;
@@ -333,10 +672,49 @@ main {
   text-align: center;
 }
 
+.site-footer__inner {
+  display: grid;
+  gap: 1rem;
+  width: min(1120px, 100%);
+  margin: 0 auto;
+}
+
+.footer-nav {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1.2rem;
+}
+
+.footer-nav a {
+  color: rgba(255, 255, 255, 0.85);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.footer-nav a:hover,
+.footer-nav a:focus {
+  color: #fff;
+}
+
 .site-footer__credits {
   margin-top: 0.4rem;
   font-size: 0.95rem;
   color: rgba(255, 255, 255, 0.64);
+}
+
+@media (max-width: 720px) {
+  .site-nav {
+    display: none;
+  }
+
+  .site-header__cta {
+    margin-left: auto;
+  }
+
+  .hero {
+    padding: clamp(2rem, 6vw, 3rem);
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/public/terminos/index.html
+++ b/public/terminos/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Términos y condiciones · Drunkitties</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Nunito:wght@400;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="../style.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="site-header__container">
+        <a class="site-logo" href="/">🐾 Drunkitties</a>
+        <nav class="site-nav" aria-label="Principal">
+          <a href="/">Inicio</a>
+          <a href="/productos/">Productos</a>
+          <a href="/personalizar/">Personalizar</a>
+          <a href="/contacto/">Contacto</a>
+        </nav>
+        <a class="site-header__cta" href="/personalizar/">Empieza ahora</a>
+      </div>
+    </header>
+
+    <main class="page-main">
+      <section class="page-hero">
+        <h1 class="page-hero__title">Términos y condiciones</h1>
+        <p class="page-hero__subtitle">Lee con atención las reglas que aplican al usar Drunkitties Studio y adquirir nuestros productos.</p>
+      </section>
+
+      <section class="rich-text">
+        <h2>1. Aceptación de términos</h2>
+        <p>Al acceder al sitio aceptas estos términos. Si no estás de acuerdo, por favor no utilices el servicio.</p>
+
+        <h2>2. Uso permitido</h2>
+        <p>Los diseños generados son para uso personal o comercial limitado por el comprador. No pueden revenderse sin modificaciones.</p>
+
+        <h2>3. Pagos y envíos</h2>
+        <p>Todos los precios están expresados en euros e incluyen IVA. Los envíos se realizan en un plazo estimado de 7 a 10 días hábiles.</p>
+
+        <h2>4. Propiedad intelectual</h2>
+        <p>Drunkitties conserva los derechos sobre la plataforma y el generador. Tú conservas los derechos sobre las fotos que subes.</p>
+
+        <h2>5. Contacto</h2>
+        <p>Para aclaraciones sobre estos términos escríbenos a <a href="mailto:legal@drunkitties.studio">legal@drunkitties.studio</a>.</p>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="site-footer__inner">
+        <p>Hecho con ❤️ para amantes de los bigotes inquietos.</p>
+        <nav class="footer-nav" aria-label="Legal">
+          <a href="/sobre-nosotros/">Sobre nosotros</a>
+          <a href="/privacidad/">Política de privacidad</a>
+          <a href="/terminos/" aria-current="page">Términos y condiciones</a>
+          <a href="/contacto/">Contacto</a>
+        </nav>
+        <p class="site-footer__credits">© 2025 Drunkitties Studio. Todos los derechos reservados.</p>
+      </div>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a shared navigation bar and footer while refreshing the home hero to align with the new visual language
- implement the product catalog and personalization screens inspired by the provided mockups
- add supporting pages for cart, checkout, about, contact, privacy, and terms to complete the site map

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5d98aa4308333972b554d8e034733